### PR TITLE
fix(article-page): fix download controls appearing for non uq/slq users

### DIFF
--- a/angular/app/views/article.html
+++ b/angular/app/views/article.html
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<div class="alert alert-warning" ng-show="Auth.isUQSLQ()" style="margin: 0;" ng-hide="$state.includes('article.edit')">
+<div class="alert alert-warning" ng-show="Auth.isUQSLQ() && !$state.includes('article.edit')" style="margin: 0;">
   <div class="container">
     <!-- Download dropdown -->
     <div class="btn-group" ng-hide="$state.includes('article.edit')">


### PR DESCRIPTION
Closes #48

The check for UQ SLQ was broken because of that extra ng-hide. Should be fixed now.
