### PR TITLE
fix(interview-upload): remove requirement for audio file and transcript

### DIFF
--- a/angular/app/views/upload.interviews.html
+++ b/angular/app/views/upload.interviews.html
@@ -171,7 +171,7 @@
                 </div>
 
                 <div class="form-group">
-                    <button class="btn btn-primary" ng-click="create(interview)" ng-disabled="form.$invalid || !(interview.$audioFiles.length || interview.files.length)">
+                    <button class="btn btn-primary" ng-click="create(interview)" ng-disabled="form.$invalid">
                         {{ interview.uri && 'Update' || 'Create' }}
                     </button>
                     <button class="btn btn-default" ng-click="cancel()">Cancel</button>


### PR DESCRIPTION
Closes #116

Users can now create an interview, with pretty much nothing. They don't need an audio file or a transcript.
