### PR TITLE
fix(entity-class): fix entities faulty preferred images

### DIFF
--- a/angular/app/scripts/services/entity.js
+++ b/angular/app/scripts/services/entity.js
@@ -93,7 +93,7 @@ angular.module('angularApp')
                             imageUri = imageUri[0];
                         }
                         var expression = expressions[imageUri];
-                        if (angular.isDefined(expression.file)) {
+                        if (expression && angular.isDefined(expression.file)) {
                             entity.picture = expression.file;
                         }
                     }


### PR DESCRIPTION
Closes #124

Some entities have a preferred image value set that is pointing to an
expression that no longer exists. It now checks if the expression
exists, before trying to access it.
